### PR TITLE
Egress stream callback bugfix

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -190,9 +190,11 @@ func (client *natsClient) natsMsgHandler(handler MessageHandler) nats.MsgHandler
 		if err != nil {
 			log.Printf("unable to unmarshal data from %s", msg.Subject)
 		}
-		hMsg := &Message{
-			Payload: tMsg.Payload[0],
+		for _, payload := range tMsg.GetPayload() {
+			hMsg := &Message{
+				Payload: payload,
+			}
+			handler(hMsg)
 		}
-		handler(hMsg)
 	}
 }

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/nats-io/nats-server/v2/server"
 	natsserver "github.com/nats-io/nats-server/v2/test"
+	connectorpb "github.com/nutanix/kps-connector-go-sdk/connector/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,8 +73,48 @@ func TestNewTransportClient(t *testing.T) {
 		err = client.Publish(channel, Message{Payload: msg})
 		require.NoError(t, err)
 
-		time.Sleep(time.Second * 10)
+		time.Sleep(time.Second * 5)
 		assert.True(t, <-called)
+
+		err = sub.Unsubscribe()
+		assert.NoError(t, err)
+	})
+
+	t.Run("transport calls callback multiple times for multiple messages in one nats payload", func(t *testing.T) {
+		channel := "testchannel"
+		client, err := NewTransportClient()
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		validateMap := map[string]bool{
+			"foo": false,
+			"bar": false,
+		}
+
+		cb := func(m *Message) {
+			payload := string(m.Payload)
+			assert.Contains(t, validateMap, payload)
+			validateMap[payload] = true
+		}
+
+		sub, err := client.Subscribe(channel, cb)
+		require.NoError(t, err)
+		assert.Equal(t, channel, sub.Channel())
+
+		nc, ok := client.(*natsClient)
+		require.True(t, ok)
+		require.NotNil(t, nc)
+		tMsg := &connectorpb.TransportMessage{
+			Timestamp: time.Now().UnixNano(),
+			Payload:   [][]byte{[]byte("foo"), []byte("bar")},
+		}
+		data, err := proto.Marshal(tMsg)
+		require.NoError(t, err)
+		err = nc.conn.Publish(channel, data)
+		require.NoError(t, err)
+
+		time.Sleep(time.Second * 5)
+		assert.True(t, validateMap["foo"])
+		assert.True(t, validateMap["bar"])
 
 		err = sub.Unsubscribe()
 		assert.NoError(t, err)


### PR DESCRIPTION
Ensure callback function passed during subscribe call gets
called for each item in the egress stream payload.